### PR TITLE
fix(forms): Implement robust business logic validation and data integ…

### DIFF
--- a/hypersender-transport-codeChallenge/app/Filament/Resources/DriverResource.php
+++ b/hypersender-transport-codeChallenge/app/Filament/Resources/DriverResource.php
@@ -40,7 +40,7 @@ protected static ?int $navigationSort = 3;
             Forms\Components\TextInput::make('license_number')
                 ->required()
                 ->maxLength(50)
-                ->unique(), // Ensure no duplicate licenses
+                ->unique(ignoreRecord: true), // Ensure no duplicate licenses
             Forms\Components\TextInput::make('phone')
                 ->maxLength(30)
                 ->tel(),

--- a/hypersender-transport-codeChallenge/app/Filament/Resources/PromoResource.php
+++ b/hypersender-transport-codeChallenge/app/Filament/Resources/PromoResource.php
@@ -29,15 +29,15 @@ protected static ?int $navigationSort = 6;
             ->schema([
                  Forms\Components\TextInput::make('code')
                     ->required()
-                    ->unique()
+                    ->unique(ignoreRecord: true)
                     ->maxLength(20),
                 Forms\Components\TextInput::make('discount')
                     ->required()
                     ->numeric()
                     ->minValue(0)
                     ->maxValue(100),
-                Forms\Components\DatePicker::make('valid_from')->required(),
-                Forms\Components\DatePicker::make('valid_until')->required(),
+                Forms\Components\DatePicker::make('valid_from') ->required() ->live(),
+                Forms\Components\DatePicker::make('valid_until')->required() ->after('valid_from'),
                 Forms\Components\Toggle::make('active')
                     ->default(true)
                     ->label('Active'),

--- a/hypersender-transport-codeChallenge/app/Filament/Resources/TripResource.php
+++ b/hypersender-transport-codeChallenge/app/Filament/Resources/TripResource.php
@@ -21,8 +21,17 @@ protected static ?string $navigationIcon = 'heroicon-o-map';
 
     public static function form(Form $form): Form
     {
+
+        
+
+
         return $form
              ->schema([
+
+                Forms\Components\TextInput::make('name')
+                ->required()
+                ->maxLength(255),
+
             Forms\Components\Select::make('company_id')
                 ->label('Company')
                 ->relationship('company', 'name')
@@ -48,8 +57,8 @@ protected static ?string $navigationIcon = 'heroicon-o-map';
                 ->required()
                 ->maxLength(255),
 
-            Forms\Components\DateTimePicker::make('start_time')->required(),
-            Forms\Components\DateTimePicker::make('end_time')->required(),
+            Forms\Components\DateTimePicker::make('start_time')->required()->rules(['after_or_equal:today']),
+            Forms\Components\DateTimePicker::make('end_time')->required()->rules(['after:start_time']),
             ]);
     }
 

--- a/hypersender-transport-codeChallenge/app/Filament/Resources/VehicleResource.php
+++ b/hypersender-transport-codeChallenge/app/Filament/Resources/VehicleResource.php
@@ -35,7 +35,7 @@ protected static ?string $navigationIcon = 'heroicon-o-truck';
                     ->searchable(),
 
                     Forms\Components\TextInput::make('model')->required()->maxLength(255),
-                Forms\Components\TextInput::make('plate_number')->unique()->required()->maxLength(100),
+                Forms\Components\TextInput::make('plate_number')->unique(ignoreRecord: true)->required()->maxLength(100),
                 Forms\Components\Select::make('status')
                     ->options([
                         'active' => 'Active',

--- a/hypersender-transport-codeChallenge/app/Models/Company.php
+++ b/hypersender-transport-codeChallenge/app/Models/Company.php
@@ -19,6 +19,7 @@ class Company extends Model
         'name',
         'address',
         'contact_info',
+        'company_id',
     ];
 
     /**

--- a/hypersender-transport-codeChallenge/app/Models/Trip.php
+++ b/hypersender-transport-codeChallenge/app/Models/Trip.php
@@ -1,19 +1,32 @@
 <?php
 
 namespace App\Models;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Relations\BelongsTo; // Important: Add this use statement
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Trip extends Model
 {
     use HasFactory;
-    public function scopeActive(Builder $query): Builder
-    {
-        return $query->where('status', 'active');
-    }
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+        'company_id',
+        'driver_id',
+        'vehicle_id',
+        'promo_id',
+        'origin',
+        'destination',
+        'start_time',
+        'end_time',
+        'status',
+    ];
 
     /**
      * Get the driver for the trip.
@@ -32,7 +45,7 @@ class Trip extends Model
     }
 
     /**
-     * Get the company for the trip. (This was the missing one)
+     * Get the company for the trip.
      */
     public function company(): BelongsTo
     {

--- a/hypersender-transport-codeChallenge/app/Observers/PromoObserver.php
+++ b/hypersender-transport-codeChallenge/app/Observers/PromoObserver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Promo;
+use Illuminate\Support\Carbon;
+
+class PromoObserver
+{
+    /**
+     * Handle the Promo "saving" event.
+     */
+    public function saving(Promo $promo): void
+    {
+        // Check if the valid_until date is set and is in the past
+        if ($promo->valid_until && Carbon::parse($promo->valid_until)->isPast()) {
+            $promo->active = false;
+        }
+    }
+}

--- a/hypersender-transport-codeChallenge/app/Providers/AppServiceProvider.php
+++ b/hypersender-transport-codeChallenge/app/Providers/AppServiceProvider.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace App\Providers;
+use App\Models\Promo; 
+use App\Observers\PromoObserver;
 
 use Illuminate\Support\ServiceProvider;
 
@@ -19,6 +21,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Promo::observe(PromoObserver::class);
     }
 }


### PR DESCRIPTION
…rity

This commit introduces a series of critical fixes and enhancements to the validation logic across all Filament resources, ensuring higher data integrity and preventing illogical user input.

Key Changes:

- **Drivers & Vehicles:** Resolved a bug where editing a record would fail due to a unique constraint violation. The validation rule for  and  has been updated to ignore the current record ID during the uniqueness check ().

- **Trips:** Users are now prevented from creating trips with dates in the past. The  must be today or in the future, and the  must be chronologically after the .

- **Promos (Logical Date Range):** Corrected a critical logic flaw where a promotion's 'valid until' date could be set before its 'valid from' date. The validation now strictly enforces that the end date must occur after the start date, using Filament's  method for reliable comparison.

- **Promos (Automatic Deactivation):** Implemented a  to automatically manage the  status of promotions. When a promo is saved, the observer checks if its  date is in the past and, if so, sets its status to . This ensures the active status of promos is always accurate without manual intervention.